### PR TITLE
fix(calculator): bgp xp not working

### DIFF
--- a/web/templates/calculator.templ
+++ b/web/templates/calculator.templ
@@ -123,7 +123,7 @@ script xpCalculator(
 		});
 		subjectSelect.addEventListener("change", () => {
 			for (const subject of subjects) {
-				if (subject.name == subjectSelect.selectedOptions[0].value) {
+				if (subject.name.trim() == subjectSelect.selectedOptions[0].value.trim()) {
 					xpSelect.value = subject.XP;
 					reason = subject.name;
 					updateLevel();


### PR DESCRIPTION
See #2 

The `subject.name` actually has a leading whitespace for some reason, which makes the equality never match... I trimmed both the `subject.name` and `subjectSelect.selectedOptions[0].value` and it fixes it. I trimmed both of them for robustness even if it's not useful at the moment.

It's probably trimmed somewhere else anyway and removing that trim may be better but I don't know any of this stuff :sweat_smile: 

Thanks for your work !! :heart: 